### PR TITLE
Minor edits to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,26 @@
-# Splunk Log-driver plugin for Docker
+# Splunk LogDriver plugin for Docker
 
-Splunk logging plugin allows docker containers to send their logs directly to a Splunk Enterprise service, a Splunk
-Cloud deployment, or to a SplunkNova account.
+The Splunk Log Driver plugin allows Docker containers to send their logs directly to a Splunk Enterprise service, a Splunk Cloud deployment, or to a Splunk Nova account.
 
 ## Getting Started
 
-You need to install Docker Engine >= 1.12.
+Install Docker Engine Community Edition (CE) or Enterprise Edition (EE) >= 1.12. See [Docker log driver plugins](https://docs.docker.com/engine/extend/plugins_logging/) for more information.
 
-Additional information about Docker plugins [can be found here.](https://docs.docker.com/engine/extend/plugins_logging/)
-
-
-### Developing
-
-For development, you can clone and run make
-
-```
-git clone git@github.com:splunk/docker-logging-plugin.git
-cd docker-logging-plugin
-make
-```
 
 ### Installing
 
-To install the plugin, you can run
+To install the plugin, run:
 
 ```
 docker plugin install splunk/docker-logging-driver:latest --alias splunk
 docker plugin ls
 ```
 
-This command will pull and enable the plugin
+This command pulls and enables the plugin.
 
-### Using
+### Usage
 
-The plugin uses the same parameters as the [splunk logging driver](https://docs.docker.com/engine/admin/logging/splunk/).
+You can configure Docker logging to use the splunk driver by default or on a per-container basis. The plugin uses the same parameters as the [splunk logging driver](https://docs.docker.com/engine/admin/logging/splunk/).
 
 
 #### Splunk Enterprise Example
@@ -53,9 +40,16 @@ $ docker run --log-driver=splunk \
 
 ```
 
-#### SplunkNova Example
+#### Splunk Cloud Example
 
-Once you make an account on www.splunknova.com, you can grab your API credentials and use them here.
+```
+$ docker run --example here
+
+```
+
+#### Splunk Nova Example
+
+Create an account on www.splunknova.com. Grab your API credentials and use them here.
 
 ```
 $ docker run --log-driver=splunk \
@@ -69,3 +63,12 @@ $ docker run --log-driver=splunk \
              -it ubuntu bash
 ```
 
+### Developing
+
+For development, clone and run make
+
+```
+git clone git@github.com:splunk/docker-logging-plugin.git
+cd docker-logging-plugin
+make
+```

--- a/README.md
+++ b/README.md
@@ -1,55 +1,49 @@
-# Splunk LogDriver plugin for Docker
+# Splunk Nova Loggging Driver plugin for Docker
 
-The Splunk Log Driver plugin allows Docker containers to send their logs directly to a Splunk Enterprise service, a Splunk Cloud deployment, or to a Splunk Nova account.
+The Splunk Nova Logging Driver plugin enables users to send their container logs directly to a Splunk Nova account from a Docker container. See [Splunk logging driver] to send container logs to
+[HTTP Event Collector](http://dev.splunk.com/view/event-collector/SP-CAAAE6M) in Splunk Enterprise and Splunk Cloud.
 
-## Getting Started
+## Get Started
 
-Install Docker Engine Community Edition (CE) or Enterprise Edition (EE) >= 1.12. See [Docker log driver plugins](https://docs.docker.com/engine/extend/plugins_logging/) for more information.
+Get started by creating an account on https://www.splunknova.com.
 
+### Prerequisites
 
-### Installing
+Sign up or log in to [Docker Hub]. If you have not used Docker before, see the [Getting started tutorial](https://docs.docker.com/mac/started) for Docker.
 
-To install the plugin, run:
+### Install
+
+If necessary, download and install [Docker][docker] Community Edition (CE) or Enterprise Edition (EE) >= 1.12.
+
+Open a shell prompt or Terminal window and install the `splunk/docker-logging-driver.` plugin. To pull and enable the plugin, run:
 
 ```
 docker plugin install splunk/docker-logging-driver:latest --alias splunk
-docker plugin ls
 ```
 
-This command pulls and enables the plugin.
+Verify installation by running:
 
-### Usage
+```
+$ docker plugin ls
+```
+This command lists all the Docker plugins that are currently installed.
+
+```
+ID                  NAME                               TAG                 DESCRIPTION                ENABLED
+89443ca1c345        splunknova/docker-logging-plugin   latest              Nova plugin for Docker     true
+```
+
+### Configure
 
 You can configure Docker logging to use the splunk driver by default or on a per-container basis. The plugin uses the same parameters as the [splunk logging driver](https://docs.docker.com/engine/admin/logging/splunk/).
 
+## Usage
 
-#### Splunk Enterprise Example
-
-```
-$ docker run --log-driver=splunk \
-             --log-opt splunk-url=https://your-splunkhost:8088 \
-             --log-opt splunk-token=176FCEBF-4CF5-4EDF-91BC-703796522D20 \
-             --log-opt splunk-capath=/path/to/cert/cacert.pem \
-             --log-opt splunk-caname=SplunkServerDefaultCert \
-             --log-opt tag="{{.Name}}/{{.FullID}}" \
-             --log-opt labels=location \
-             --log-opt env=TEST \
-             --env "TEST=false" \
-             --label location=west \
-             -it ubuntu bash
-
-```
-
-#### Splunk Cloud Example
-
-```
-$ docker run --example here
-
-```
+Create an account on [www.splunknova.com][Splunk Nova]. Grab your API credentials and use them here.
 
 #### Splunk Nova Example
 
-Create an account on www.splunknova.com. Grab your API credentials and use them here.
+Once you have your API credentials, replace the `splunk-token` with your Base-64 Encoded API Key from https://www.splunknova.com/apikeys.
 
 ```
 $ docker run --log-driver=splunk \
@@ -63,12 +57,20 @@ $ docker run --log-driver=splunk \
              -it ubuntu bash
 ```
 
-### Developing
+### Development
 
-For development, clone and run make
+To contribute to development, clone and run make
 
 ```
 git clone git@github.com:splunk/docker-logging-plugin.git
 cd docker-logging-plugin
 make
 ```
+
+See [Docker log driver plugins](https://docs.docker.com/engine/extend/plugins_logging/) for more information.
+
+[docker]: https://www.docker.com/get-docker
+[Docker Hub]: https://hub.docker.com
+[HTTP Event Collector]: http://dev.splunk.com/view/event-collector/SP-CAAAE6M
+[Splunk logging driver]: https://docs.docker.com/engine/admin/logging/splunk/
+[Splunk Nova]: https://splunknova.com

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Splunk Nova Loggging Driver plugin for Docker
+# Splunk Nova Logging Driver plugin for Docker
 
 The Splunk Nova Logging Driver plugin enables users to send their container logs directly to a Splunk Nova account from a Docker container. See [Splunk logging driver] to send container logs to
 [HTTP Event Collector](http://dev.splunk.com/view/event-collector/SP-CAAAE6M) in Splunk Enterprise and Splunk Cloud.


### PR DESCRIPTION
Suggestion: Create a Splunk Cloud Example, or if Splunk Cloud is similar combine both under the headline: Splunk Enterprise and Splunk Cloud Example. 
Removed the Splunk Enterprise and Splunk Cloud mentions and kept scope to Splunk Nova only, instead redirecting users to the https://docs.docker.com/engine/admin/logging/splunk for Enterprise and Cloud.